### PR TITLE
Fix for VNC HTML Viewer if VM Dashboard running on different port

### DIFF
--- a/pages/domain/domain-single.php
+++ b/pages/domain/domain-single.php
@@ -65,7 +65,7 @@
     $domName = $lv->domain_get_name_by_uuid($uuid);
     $dom = $lv->get_domain_object($domName);
     $protocol = isset($_SERVER['HTTPS']) ? "https://" : "http://";
-    $url = $protocol . $_SERVER['HTTP_HOST'];
+    $url = $protocol . $_SERVER['SERVER_NAME'];
     $page = basename($_SERVER['PHP_SELF']);
     $action = $_SESSION['action'];
     $domXML = new SimpleXMLElement($lv->domain_get_xml($domName));

--- a/pages/vnc.php
+++ b/pages/vnc.php
@@ -10,7 +10,7 @@ if (!isset($_SESSION['username'])){
 }
 
 $protocol = isset($_SERVER['HTTPS']) ? "https://" : "http://";
-$url = $protocol . $_SERVER['HTTP_HOST'];
+$url = $protocol . $_SERVER['SERVER_NAME'];
 $token = $_GET['token'];
 ?>
 


### PR DESCRIPTION
Fix for URL with different port number than 80 or 443.

Let assume URL is http://serverurl:9999, the iframe generated is http://serverurl:9999:6080/vnc_lite.html....... which doesn't show the vnc's html viewer.